### PR TITLE
Version 1.0.2.0

### DIFF
--- a/WinEventLogCustomization/WinEventLogCustomization.psd1
+++ b/WinEventLogCustomization/WinEventLogCustomization.psd1
@@ -3,7 +3,7 @@
     RootModule           = 'WinEventLogCustomization.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.0.1'
+    ModuleVersion        = '1.0.2'
 
     # ID used to uniquely identify this module
     GUID                 = '9268705a-75d5-401c-b13d-4d1a8f380b17'

--- a/WinEventLogCustomization/changelog.md
+++ b/WinEventLogCustomization/changelog.md
@@ -1,9 +1,11 @@
 ﻿# Changelog
-## 1.0.1 (2022-09-24)
+## 1.0.2 (2022-09-24)
  - New: ---
- - Upd: ---
+ - Upd:
+   - Unregister-WELCEventChannelManifest: Extend deregistration process with scanning registry for provider/ event source artifacts on channels from manifest that is going to unregister 
  - Fix:
-    - Set-WELCEventChannel: bugfix hashtable value mistake, that prevent you from using the function
+   - New-WELCEventChannelManifest: make WhatIf switch effective on command
+   - Set-WELCEventChannel: bugfix hashtable value mistake, that prevent you from using the function
 
 ## 1.0.0 (2022-07-24)
 First official release.

--- a/WinEventLogCustomization/functions/New-WELCEventChannelManifest.ps1
+++ b/WinEventLogCustomization/functions/New-WELCEventChannelManifest.ps1
@@ -238,7 +238,7 @@
         if (Test-Path -Path $TempPath -IsValid) {
             if (-not (Test-Path -Path $TempPath -PathType Container)) {
                 Write-PSFMessage -Level Debug -Message "Creating temporary directory '$($TempPath)'"
-                New-Item -Path $TempPath -ItemType Directory -Force | Out-Null
+                New-Item -Path $TempPath -ItemType Directory -Force -WhatIf:$false | Out-Null
                 $TempPath = Resolve-Path $TempPath -ErrorAction Stop | Select-Object -ExpandProperty Path
             }
         } else {
@@ -501,7 +501,8 @@
                 -ArgumentList $fullNameManifestTemp `
                 -WorkingDirectory $TempPath `
                 -NoNewWindow `
-                -Wait
+                -Wait `
+                -WhatIf:$false
 
             Write-PSFMessage -Level Debug -Message "Validating generated files"
             foreach ($tempFile in $tempFilesExpected) {
@@ -523,7 +524,8 @@
                 -ArgumentList "-css NameSpace $($fullNameManifestTemp)" `
                 -WorkingDirectory $TempPath `
                 -NoNewWindow `
-                -Wait
+                -Wait `
+                -WhatIf:$false
 
             Write-PSFMessage -Level Debug -Message "Validating generated '$($fileName).cs' file"
             foreach ($tempFile in $tempFilesExpected) {
@@ -545,7 +547,8 @@
                 -ArgumentList "$($fileName).rc" `
                 -WorkingDirectory $TempPath `
                 -Wait `
-                -WindowStyle Hidden
+                -WindowStyle Hidden `
+                -WhatIf:$false
 
             Write-PSFMessage -Level Debug -Message "Validating generated '$($fileName).res' file"
             foreach ($tempFile in $tempFilesExpected) {
@@ -565,7 +568,8 @@
                 -ArgumentList "/win32res:$($TempPath)\$($fileName).res /unsafe /target:library /out:$($TempPath)\$($fileName).dll $($TempPath)\$($fileName).cs" `
                 -WorkingDirectory $TempPath `
                 -Wait `
-                -WindowStyle Hidden
+                -WindowStyle Hidden `
+                -WhatIf:$false
 
             Write-PSFMessage -Level Debug -Message "Validating generated '$($fileName).dll' file"
             foreach ($FinalFile in $finalFilesExpected) {
@@ -590,7 +594,7 @@
 
         #region Cleanup
         Write-PSFMessage -Level Verbose -Message "Cleaning up temporary path '$($TempPath)'"
-        Remove-Item -Path $TempPath -Force -Recurse -ErrorAction SilentlyContinue
+        Remove-Item -Path $TempPath -Force -Recurse -ErrorAction SilentlyContinue -WhatIf:$false
         #endregion Cleanup
     }
 }

--- a/WinEventLogCustomization/functions/Set-WELCEventChannel.ps1
+++ b/WinEventLogCustomization/functions/Set-WELCEventChannel.ps1
@@ -283,17 +283,27 @@
             "EventChannel" {
                 foreach ($eventChannelItem in $EventChannel) {
                     Write-PSFMessage -Level Debug -Message "Collecting config object for '$($eventChannelItem.ChannelFullName)' on '$($eventChannelItem.ComputerName)'"
+
+                    if (Test-PSFParameterBinding -ParameterName MaxEventLogSize) { $_MaxEventLogSize = $MaxEventLogSize }else { $_MaxEventLogSize = $null }
+                    if (Test-PSFParameterBinding -ParameterName LogMode) { $_LogMode = $LogMode } else { $_LogMode = $null }
+                    if ($logFileFullName -like "ToBeCalculated") { $_LogFileFullName = "$($logFileFolder)\$($eventChannelItem.LogFile)" } elseif (Test-PSFParameterBinding -ParameterName LogFilePath) { $_LogFileFullName = $logFileFullName } else { $_LogFileFullName = $null }
+                    if (Test-PSFParameterBinding -ParameterName LogFilePath) { $_LogFilePath = $logFileFolder } else { $_LogFilePath = $null }
+                    if (Test-PSFParameterBinding -ParameterName Enabled) { $_Enabled = $Enabled } else { $_Enabled = $null }
+                    if (Test-PSFParameterBinding -ParameterName CompressLogFolder) { $_CompressLogFolder = $CompressLogFolder } else { $_CompressLogFolder = $null }
+                    if (Test-PSFParameterBinding -ParameterName AllowFileAccessForLocalService) { $_AllowFileAccessForLocalService = $AllowFileAccessForLocalService } else { $_AllowFileAccessForLocalService = $null }
+                    if (Test-PSFParameterBinding -ParameterName EventChannelSDDL) { $_EventChannelSDDL = $EventChannelSDDL } else { $_EventChannelSDDL = $null }
+
                     $null = $configList.Add(
                         [PSCustomObject]@{
                             EventChannel                   = $eventChannelItem
-                            Enabled                        = (.{ if (Test-PSFParameterBinding -ParameterName Enabled) { $Enabled } })
-                            MaxEventLogSize                = (.{ if (Test-PSFParameterBinding -ParameterName MaxEventLogSize) { $MaxEventLogSize } })
-                            LogMode                        = (.{ if (Test-PSFParameterBinding -ParameterName LogMode) { $LogMode } })
-                            LogFileFullName                = (.{ if ($logFileFullName -like "ToBeCalculated") { "$($logFileFolder)\$($eventChannelItem.LogFile)" } elseif (Test-PSFParameterBinding -ParameterName LogFilePath) { $logFileFullName } })
-                            LogFilePath                    = (.{ if (Test-PSFParameterBinding -ParameterName LogFilePath) { $logFileFolder } })
-                            CompressLogFolder              = (.{ if (Test-PSFParameterBinding -ParameterName CompressLogFolder) { $CompressLogFolder } })
-                            AllowFileAccessForLocalService = (.{ if (Test-PSFParameterBinding -ParameterName AllowFileAccessForLocalService) { $AllowFileAccessForLocalService } })
-                            EventChannelSDDL               = (.{ if (Test-PSFParameterBinding -ParameterName EventChannelSDDL) { $EventChannelSDDL } })
+                            Enabled                        = $_Enabled
+                            MaxEventLogSize                = $_MaxEventLogSize
+                            LogMode                        = $_LogMode
+                            LogFileFullName                = $_LogFileFullName
+                            LogFilePath                    = $_LogFilePath
+                            CompressLogFolder              = $_CompressLogFolder
+                            AllowFileAccessForLocalService = $_AllowFileAccessForLocalService
+                            EventChannelSDDL               = $_EventChannelSDDL
                         }
                     )
                 }
@@ -307,17 +317,27 @@
                         if ($eventChannel) {
                             foreach ($eventChannelItem in $eventChannel) {
                                 Write-PSFMessage -Level Debug -Message "Collecting config object for '$($eventChannelItem.Name)' on '$($computer)'"
+
+                                if (Test-PSFParameterBinding -ParameterName MaxEventLogSize) { $_MaxEventLogSize = $MaxEventLogSize }else { $_MaxEventLogSize = $null }
+                                if (Test-PSFParameterBinding -ParameterName LogMode) { $_LogMode = $LogMode } else { $_LogMode = $null }
+                                if ($logFileFullName -like "ToBeCalculated") { $_LogFileFullName = "$($logFileFolder)\$($eventChannelItem.LogFile)" } elseif (Test-PSFParameterBinding -ParameterName LogFilePath) { $_LogFileFullName = $logFileFullName } else { $_LogFileFullName = $null }
+                                if (Test-PSFParameterBinding -ParameterName LogFilePath) { $_LogFilePath = $logFileFolder } else { $_LogFilePath = $null }
+                                if (Test-PSFParameterBinding -ParameterName Enabled) { $_Enabled = $Enabled } else { $_Enabled = $null }
+                                if (Test-PSFParameterBinding -ParameterName CompressLogFolder) { $_CompressLogFolder = $CompressLogFolder } else { $_CompressLogFolder = $null }
+                                if (Test-PSFParameterBinding -ParameterName AllowFileAccessForLocalService) { $_AllowFileAccessForLocalService = $AllowFileAccessForLocalService } else { $_AllowFileAccessForLocalService = $null }
+                                if (Test-PSFParameterBinding -ParameterName EventChannelSDDL) { $_EventChannelSDDL = $EventChannelSDDL } else { $_EventChannelSDDL = $null }
+
                                 $null = $configList.Add(
                                     [PSCustomObject]@{
                                         EventChannel                   = $eventChannelItem
-                                        Enabled                        = ( if (Test-PSFParameterBinding -ParameterName Enabled) { $Enabled } )
-                                        MaxEventLogSize                = ( if (Test-PSFParameterBinding -ParameterName MaxEventLogSize) { $MaxEventLogSize } )
-                                        LogMode                        = ( if (Test-PSFParameterBinding -ParameterName LogMode) { $LogMode } )
-                                        LogFileFullName                = ( if ($logFileFullName -like "ToBeCalculated") { "$($logFileFolder)\$($eventChannelItem.LogFile)" } elseif (Test-PSFParameterBinding -ParameterName LogFilePath) { $logFileFullName } )
-                                        LogFilePath                    = ( if (Test-PSFParameterBinding -ParameterName LogFilePath) { $logFileFolder } )
-                                        CompressLogFolder              = ( if (Test-PSFParameterBinding -ParameterName CompressLogFolder) { $CompressLogFolder } )
-                                        AllowFileAccessForLocalService = ( if (Test-PSFParameterBinding -ParameterName AllowFileAccessForLocalService) { $AllowFileAccessForLocalService } )
-                                        EventChannelSDDL               = ( if (Test-PSFParameterBinding -ParameterName EventChannelSDDL) { $EventChannelSDDL } )
+                                        Enabled                        = $_Enabled
+                                        MaxEventLogSize                = $_MaxEventLogSize
+                                        LogMode                        = $_LogMode
+                                        LogFileFullName                = $_LogFileFullName
+                                        LogFilePath                    = $_LogFilePath
+                                        CompressLogFolder              = $_CompressLogFolder
+                                        AllowFileAccessForLocalService = $_AllowFileAccessForLocalService
+                                        EventChannelSDDL               = $_EventChannelSDDL
                                     }
                                 )
                             }


### PR DESCRIPTION
- Upd:
   - Unregister-WELCEventChannelManifest: Extend deregistration process with scanning registry for provider/ event source artifacts on channels from manifest that is going to unregister 
- Fix:
   - New-WELCEventChannelManifest: make WhatIf switch effective on command
   - Set-WELCEventChannel: bugfix hashtable value mistake, that prevent you from using the function